### PR TITLE
Add build error info back

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,11 @@ def resolveReactNativeDirectory() {
       return reactNativeFromProjectNodeModules
     }
   } catch (e) {
-    // Ignore
+    throw new Exception(
+      "${project.name}: Failed to resolve 'react-native' in the project. " +
+      "Altenatively, you can specify 'reactNativeDir' with the path to 'react-native' in your 'gradle.properties' file." + 
+      "${e}"
+    )
   }
 
   throw new Exception(


### PR DESCRIPTION
I had hard time building the project cause of this error swallow, which is also a bad practice.
In my case `node` path was missing for Android studio and the inner error was:
```
A problem occurred evaluating project ':react-native-drop-shadow'.
> A problem occurred starting process 'command 'node''
```    